### PR TITLE
Fix Update SpellDarkStorage.au3

### DIFF
--- a/COCBot/functions/Attack/SpellDarkStorage.au3
+++ b/COCBot/functions/Attack/SpellDarkStorage.au3
@@ -10,6 +10,7 @@ Func SpellDarkStorage()
 	Local $SDark
 	Local $LightPosition[11]
 	Local $LightSpell
+	Local $SpellTimeOut = 0
 
 	$SDark = getDarkElixir(51, 66 + 57)
 
@@ -33,6 +34,8 @@ Func SpellDarkStorage()
 		  If _Sleep(500) Then Return
 		  While _WaitForPixel(68 + (72 * $LSpell), 624, Hex(0x0848ED, 6), 5, 500, 500)
 			 Click($DElixx, $DElixy)
+			 $SpellTimeOut += 1
+			 If ($SpellTimeOut >= 10) Then ExitLoop
 		  WEnd
 		  $CreateSpell = True
 	   ElseIf ($SDark - $SpellMinDarkStorage <= -1 And $castSpell < 1) Then

--- a/COCBot/functions/Attack/TroopDeploy.au3
+++ b/COCBot/functions/Attack/TroopDeploy.au3
@@ -96,6 +96,8 @@ Func IdentifyTroopKind($position)
 	EndIf
 	If _ColorCheck($TroopPixel, Hex(0x60A4D0, 6), 10) And _ColorCheck($WallBPixel, Hex(0x302A2A, 6), 10) Then Return $eWallbreaker ;Check if slot is Wallbreaker
 	If _ColorCheck($TroopPixel, Hex(0x4CA0D2, 6), 10) Then Return $eMinion
+	If _ColorCheck($TroopPixel, Hex(0x3C76B4, 6), 20) Then Return $eMinion
+	If _ColorCheck($TroopPixel, Hex(0x4392C9, 6), 20) Then Return $eMinion
 
 	;$OtherPixel = _GetPixelColor(68 + (72 * $position), 588)
 	;If _ColorCheck($OtherPixel, Hex(0x7031F0, 6), 20) Or _ColorCheck($TroopPixel, Hex(0x421E3F, 6), 20) Then Return $eQueen ;Check if slot is Queen <= level 10 Or Check if slot is Queen > level 10


### PR DESCRIPTION
give some update to exitloop spell dropping after 10 tries, so when bot false detection CC as Spell it can exit from infinity loop
